### PR TITLE
fix typo + add service_response callback to OnMessage + remove service e response callback from Process

### DIFF
--- a/Source/UROSBridge/Public/ROSBridgeGameInstance.h
+++ b/Source/UROSBridge/Public/ROSBridgeGameInstance.h
@@ -3,16 +3,16 @@
 
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
-#include "ROSBRidgeHandler.h"
+#include "ROSBridgeHandler.h"
 
 #include "ROSBridgeGameInstance.generated.h"
 
 /**
  * Base class for an example GameInstance that holds an instance of FROSBridgeHandler.
  * The class is tickable and will call FROSBridgeHandler::Process() on every Tick.
- * To use this class, create a derived blueprint from it, configure 
- * ROSBridgeServerHost and ROSBridgeServerPort if necessary and set 
- * this Blueprint as the Game Instance for your project. This can be done 
+ * To use this class, create a derived blueprint from it, configure
+ * ROSBridgeServerHost and ROSBridgeServerPort if necessary and set
+ * this Blueprint as the Game Instance for your project. This can be done
  * in the UE4Editor -> Project Settings -> Maps & Modes.
  */
 UCLASS()
@@ -28,7 +28,7 @@ class UROSBRIDGE_API UROSBridgeGameInstance : public UGameInstance, public FTick
 	virtual void OnStart() override;
 	// Cleanup opportunity when shutting down
 	virtual void Shutdown() override;
-	
+
 	/* FTickableGameObject interface */
 	virtual void Tick(float DeltaTime) override;
 	virtual bool IsTickable() const override;

--- a/Source/UROSBridge/Public/ROSBridgeHandler.h
+++ b/Source/UROSBridge/Public/ROSBridgeHandler.h
@@ -16,17 +16,17 @@
 #include "WebSocket.h"
 
 
-class UROSBRIDGE_API FROSBridgeHandler 
+class UROSBRIDGE_API FROSBridgeHandler
 {
 
 private:
 	/* Subclasses */
-	
-	/** 
+
+	/**
 	* FProcessTask: Representation of subscribed messages,
 	*			  can be processed by Process()
 	*/
-	struct FProcessTask 
+	struct FProcessTask
 	{
 		FProcessTask(
 			TSharedPtr<FROSBridgeSubscriber> InSubscriber,
@@ -44,9 +44,9 @@ private:
 	};
 
 	/**
-	* FServiceTask: Service call results, can be processed by Process() 
+	* FServiceTask: Service call results, can be processed by Process()
 	*/
-	struct FServiceTask 
+	struct FServiceTask
 	{
 		FServiceTask(
 			TSharedPtr<FROSBridgeSrvClient> InClient,
@@ -56,7 +56,7 @@ private:
 			Name(InServiceName),
 			Id(InId),
 			bIsResponsed(false),
-			bIsProcessed(false) 
+			bIsProcessed(false)
 		{
 		}
 
@@ -72,23 +72,23 @@ private:
 			Request(InRequest),
 			Response(InResponse),
 			bIsResponsed(false),
-			bIsProcessed(false) 
+			bIsProcessed(false)
 		{
 		}
 
 		TSharedPtr<FROSBridgeSrvClient> Client;
 		FString Name;
-		FString Id; 
-		TSharedPtr<FROSBridgeSrv::SrvRequest> Request; 
+		FString Id;
+		TSharedPtr<FROSBridgeSrv::SrvRequest> Request;
 		TSharedPtr<FROSBridgeSrv::SrvResponse> Response;
-		bool bIsResponsed; 
-		bool bIsProcessed; 
+		bool bIsResponsed;
+		bool bIsProcessed;
 	};
 
 	/**
 	* Thread to handle ROS communication
 	*/
-	class FROSBridgeHandlerRunnable : public FRunnable 
+	class FROSBridgeHandlerRunnable : public FRunnable
 	{
 	public:
 		FROSBridgeHandlerRunnable(
@@ -115,7 +115,7 @@ private:
 		FThreadSafeCounter StopCounter;
 		FROSBridgeHandler* Handler;
 	};
-	
+
 	FString Host;
 	int32 Port;
 	float ClientInterval;
@@ -139,14 +139,14 @@ private:
 	FROSBridgeHandlerRunnable* Runnable;
 	FRunnableThread* Thread;
 
-	FCriticalSection LockTask; 
+	FCriticalSection LockTask;
 	FCriticalSection LockArrayService;
 
 	/** Index used to disambiguate thread instances for stats reasons */
 	static int32 ThreadInstanceIdx;
 
 	/** Callback delgate that will be triggerd when Error accurs
-		User of the RosBridgeHandler can add their own callbacks by passing a 'FWebsocketInfoCallBack' to the Constructor */	
+		User of the RosBridgeHandler can add their own callbacks by passing a 'FWebsocketInfoCallBack' to the Constructor */
 	FWebsocketInfoCallBack ErrorCallbacks;
 
 	/** Callback delgate that will be triggerd when connection is established
@@ -233,7 +233,7 @@ public:
 
 	// Publish service response, used in service server
 	void PublishServiceResponse(const FString& Service, const FString& Id,
-		TSharedPtr<FROSBridgeSrv::SrvResponse> Response); 
+		TSharedPtr<FROSBridgeSrv::SrvResponse> Response);
 
 	// Publish ROS message to topics
 	void PublishMsg(const FString& Topic, TSharedPtr<FROSBridgeMsg> Msg);

--- a/Source/UROSBridge/Public/ROSBridgeSrvClient.h
+++ b/Source/UROSBridge/Public/ROSBridgeSrvClient.h
@@ -7,34 +7,34 @@
 
 #include "ROSBridgeSrv.h"
 
-class UROSBRIDGE_API FROSBridgeSrvClient 
+class UROSBRIDGE_API FROSBridgeSrvClient
 {
 protected:
-	FString Name; 
-	FString Type; 
+	FString Name;
+	FString Type;
 
 public:
-	FROSBridgeSrvClient() 
-	{
-	} 
-
-	virtual ~FROSBridgeSrvClient() 
+	FROSBridgeSrvClient()
 	{
 	}
 
-	FROSBridgeSrvClient(FString InName, FString InType): Name(InName), Type(InType) 
+	virtual ~FROSBridgeSrvClient()
 	{
 	}
 
-	FString GetName() const 
-	{ 
-		return Name; 
+	FROSBridgeSrvClient(FString InName, FString InType): Name(InName), Type(InType)
+	{
 	}
 
-	FString GetType() const 
-	{ 
-		return Type; 
+	FString GetName() const
+	{
+		return Name;
 	}
-	
-	virtual void Callback(TSharedPtr<FROSBridgeSrv::SrvRequest> InRequest, TSharedPtr<FROSBridgeSrv::SrvResponse> InResponse) = 0;
-}; 
+
+	FString GetType() const
+	{
+		return Type;
+	}
+
+	virtual void Callback(TSharedPtr<FROSBridgeSrv::SrvResponse> InResponse) = 0;
+};


### PR DESCRIPTION
I found that the callback of the response is called in the Process function of the ROSBridgeHandler. If this is added to the Tick function of the client it could also work, but I think this way is more practical.