### PR TITLE
Fix issues preventing packaging

### DIFF
--- a/Source/UROSBridge/Public/ROSBridgeGameInstance.h
+++ b/Source/UROSBridge/Public/ROSBridgeGameInstance.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
+#include "Tickable.h"
 #include "ROSBridgeHandler.h"
 
 #include "ROSBridgeGameInstance.generated.h"

--- a/Source/UROSBridge/UROSBridge.Build.cs
+++ b/Source/UROSBridge/UROSBridge.Build.cs
@@ -28,6 +28,7 @@ public class UROSBridge : ModuleRules
 			new string[]
 			{
 				"Core",
+				"Sockets"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);
@@ -42,7 +43,6 @@ public class UROSBridge : ModuleRules
 				"SlateCore",
 				"Core",
 				"Networking",
-				"Sockets",
 				"PacketHandler",
 				"libWebSockets",
 				"OpenSSL",

--- a/UROSBridge.uplugin
+++ b/UROSBridge.uplugin
@@ -16,7 +16,7 @@
   "Modules": [
 	{
 	  "Name": "UROSBridge",
-	  "Type": "Developer",
+	  "Type": "Runtime",
 	  "LoadingPhase": "Default"
 	}
   ]


### PR DESCRIPTION
A project that uses this plugin in its current state cannot be packaged and will error out while trying to build. Specific changes:

- explicitly included `Tickable.h` (required for `FTickableGameObject`)
- moved Sockets to PublicDependencyModuleNames
- marked the plugin as Runtime instead of Developer, ensuring that it is correctly loaded