### PR TITLE
Change ROSBridgeGameInstance methods to protected

### DIFF
--- a/Source/UROSBridge/Public/ROSBridgeGameInstance.h
+++ b/Source/UROSBridge/Public/ROSBridgeGameInstance.h
@@ -21,6 +21,7 @@ class UROSBRIDGE_API UROSBridgeGameInstance : public UGameInstance, public FTick
 {
 	GENERATED_BODY()
 
+protected:
 	// Default constructor
 	UROSBridgeGameInstance();
 


### PR DESCRIPTION
This allows for the creation of custom C++ game instance classes that inherit from `UROSBridgeGameInstance`