### PR TITLE
Updating Plugin to UE 4.21

### DIFF
--- a/Source/UROSBridge/UROSBridge.Build.cs
+++ b/Source/UROSBridge/UROSBridge.Build.cs
@@ -1,5 +1,6 @@
 // Copyright 2018, Institute for Artificial Intelligence - University of Bremen
 
+using System.IO;
 using UnrealBuildTool;
 
 public class UROSBridge : ModuleRules
@@ -8,21 +9,8 @@ public class UROSBridge : ModuleRules
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 		
-		PublicIncludePaths.AddRange(
-			new string[] {
-				"UROSBridge/Public"
-				// ... add public include paths required here ...
-			}
-			);
-				
-		
-		PrivateIncludePaths.AddRange(
-			new string[] {
-				"UROSBridge/Private",
-				// ... add other private include paths required here ...
-			}
-			);
-			
+        	PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+        	PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 		
 		PublicDependencyModuleNames.AddRange(
 			new string[]


### PR DESCRIPTION
Plugins being built against engine versions 4.20 onward that need to include files from their own plugin directory must add those include paths using the ModuleDirectory property in their .build.cs.
If _using System.IO;_ exists at the top of the .build.cs, Publishers can use the following syntax where "MyFolder" is the name of the directory under the current module they'd like to include:
PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "MyFolder"));