### PR TITLE
fix TCHAR_To_ANSI compile error

### DIFF
--- a/Source/UROSBridge/Private/WebSocket.cpp
+++ b/Source/UROSBridge/Private/WebSocket.cpp
@@ -61,9 +61,14 @@ FWebSocket::FWebSocket(
 }
 
 void FWebSocket::Connect(){
+  auto StrInetAdressANSI = StringCast<ANSICHAR>(*StrInetAddress);
+  const char* StrInetAdressANSIPtr = StrInetAdressANSI.Get();
+
+  auto HostAddrANSI = StringCast<ANSICHAR>(*HostAddr);
+  const char* HostAddrANSIPtr = HostAddrANSI.Get();
 
   struct lws_client_connect_info ConnectInfo = {
-			Context, TCHAR_TO_ANSI(*StrInetAddress), InetPort, false, "/", TCHAR_TO_ANSI(*HostAddr), TCHAR_TO_ANSI(*HostAddr), Protocols[1].name, -1, this
+			Context, StrInetAdressANSIPtr, InetPort, false, "/", HostAddrANSIPtr, HostAddrANSIPtr, Protocols[1].name, -1, this
 	};
   Wsi = lws_client_connect_via_info(&ConnectInfo);
   check(Wsi);


### PR DESCRIPTION
UE5.2 added new checks which prevent the use of temporary pointers such as TCHAR_To_ANSI. Functions/Macros such as this should only be used as function argument. For permanent stuff used in the struct StringCast should be used.